### PR TITLE
Add setup instructions and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:stable-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/setup.html
+++ b/setup.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>Настройка KyaMovVM</title>
+  <link rel="stylesheet" href="styles/critical.css">
+  <link rel="stylesheet" href="styles/globals.css">
+</head>
+<body class="p-4 bg-cyber-dark text-white">
+  <h1 class="text-2xl mb-4">Быстрый старт</h1>
+  <ol class="list-decimal list-inside space-y-2">
+    <li>Установите Node.js 18 или новее.</li>
+    <li>Клонируйте репозиторий: <pre><code>git clone https://github.com/example/Site-Prototype-Recreation.git</code></pre></li>
+    <li>Перейдите в каталог проекта и выполните <code>npm install</code>.</li>
+    <li>Запустите сервер разработки: <code>npm run dev</code>.</li>
+    <li>Для сборки продакшен версии выполните <code>npm run build</code>.</li>
+    <li>Также вы можете воспользоваться Dockerfile для автоматической установки зависимостей.</li>
+  </ol>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `setup.html` with Russian setup guide
- add Dockerfile for automated install and build

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npx tsc --noEmit` *(shows help output because no tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_6872bdb4e7a48332ac295ffaa5324290